### PR TITLE
GeoViewMapTilesLayer:  support several image format (Png, Jpg, etc.).

### DIFF
--- a/src/GeoView/GeoMapTile.class.st
+++ b/src/GeoView/GeoMapTile.class.st
@@ -13,8 +13,8 @@ Class {
 		'scale',
 		'graphicBounds',
 		'geoBounds',
-		'pngReference',
-		'level'
+		'level',
+		'imageReference'
 	],
 	#category : #'GeoView-Layers'
 }
@@ -56,6 +56,18 @@ GeoMapTile >> graphicBounds: anObject [
 ]
 
 { #category : #accessing }
+GeoMapTile >> imageReference [
+
+	^ imageReference
+]
+
+{ #category : #accessing }
+GeoMapTile >> imageReference: aFileReference [
+
+	imageReference := aFileReference
+]
+
+{ #category : #accessing }
 GeoMapTile >> isNoPicture [
 
 	isNoPicture ifNil:[ isNoPicture := false].
@@ -91,18 +103,6 @@ GeoMapTile >> offcenter [
 GeoMapTile >> offcenter: anOffsetInPixels [
 
 	offcenter := anOffsetInPixels
-]
-
-{ #category : #accessing }
-GeoMapTile >> pngReference [
-
-	^ pngReference
-]
-
-{ #category : #accessing }
-GeoMapTile >> pngReference: aFileReference [
-
-	pngReference := aFileReference
 ]
 
 { #category : #accessing }

--- a/src/GeoView/GeoViewMapTilesLayer.class.st
+++ b/src/GeoView/GeoViewMapTilesLayer.class.st
@@ -271,7 +271,7 @@ GeoViewMapTilesLayer >> getGeoImageAtTileXY: axyPoint level: aLevel [
 	geoImage isNoPicture: isNoPicture.
 	geoImage geoBounds: geoBounds.
 	geoImage tileXY: axyPoint.
-	geoImage pngReference: img.
+	geoImage imageReference: img.
 	geoImage level: aLevel.
 	^geoImage
 
@@ -359,12 +359,12 @@ GeoViewMapTilesLayer >> getPixelXYFromTileXY: aTilePt [
 GeoViewMapTilesLayer >> getTileSurfaceFromGeoImage: aGeoImageTile [
 
 	| tileSurface context|
-	aGeoImageTile pngReference ifNil:[
+	aGeoImageTile imageReference ifNil:[
 		tileSurface := AeCairoImageSurface extent: (self tileSize asPoint).
-		context := tileSurface newContext.
-		"context sourceColor: self class colorWithoutTile ;paint"
-	] ifNotNil:[
-		tileSurface := aGeoImageTile pngReference isForm ifTrue:[ AeCairoImageSurface fromForm: aGeoImageTile pngReference]  ifFalse:[ AeCairoImageSurface newFromPngFileAt: aGeoImageTile pngReference]
+		context := tileSurface newContext
+	] ifNotNil:[ | form |
+		form := aGeoImageTile imageReference isForm ifTrue:[ aGeoImageTile imageReference ] ifFalse:[ ImageReadWriter formFromFileNamed: aGeoImageTile imageReference ].
+		tileSurface := AeCairoImageSurface fromForm: form.
 	].
 	^tileSurface
 ]


### PR DESCRIPTION
Fix after using Jpg tiles (with local provider) instead of Png.