### PR TITLE
Fix issue #154 : compute user coordinates GBitmap size correctly + te…

### DIFF
--- a/src/GeoView-Examples/GeoViewBench.class.st
+++ b/src/GeoView-Examples/GeoViewBench.class.st
@@ -4,7 +4,7 @@ I am a bench class to test performances
 Class {
 	#name : #GeoViewBench,
 	#superclass : #Object,
-	#category : #'GeoView-Examples'
+	#category : #'GeoView-Examples-Bench'
 }
 
 { #category : #projections }

--- a/src/GeoView-Examples/GeoViewExamples.class.st
+++ b/src/GeoView-Examples/GeoViewExamples.class.st
@@ -1140,11 +1140,11 @@ GeoViewExamples class >> exampleWithDShapesLayer [
 	layer := GeoViewDShapesLayer new name: #shapes. 
 	element addLayer: layer.
 	
-	"User circle (not projected)"
+	"User circle (considering measures are in cartesian coordinates)"
 	circle1 := (SmockDCircle key: #circle1) coordinates: (element mapProjection projLatLonToCart: AbsoluteCoordinates zero); radius: 1000000; strokeColor: Color green; strokeWidth: 2.
 	layer addDShape: circle1.
 
-	"Device circle"
+	"Device circle (considering measures are in screen coordinates)"
 	circle2 := (SmockDCircle key: #circle2) coordinates: 100@100; radius: 100; strokeColor: Color yellow; strokeWidth: 2; setDrawModeDevice.
 	layer addDShape: circle2.
 
@@ -1361,6 +1361,32 @@ GeoViewExamples class >> exampleWithGeoObjectsUpdated [
 			 do: [ :event | task kill ]).
 
 	^ space
+]
+
+{ #category : #'examples - dshapeslayer' }
+GeoViewExamples class >> exampleWithUserDrawModeImage [
+	"Display the pharo logo image of 32m x 32m on the Brest city"
+	
+	| element layer image |
+	element := GeoViewElement new.
+	element addLayer: GeoViewMapTilesLayer newWithOpenStreetMap.
+	
+	layer := GeoViewDShapesLayer new name: #shapes.
+	element addLayer: layer.
+
+	"User image (considering measures are in cartesian coordinates)"
+	image := (SmockDImage key: #image1)
+		         coordinates:
+			         (element mapProjection projLatLonToCart:
+					          AbsoluteCoordinates frBrest);
+		         image: (self iconNamed: #pharo); "this image is 32x32 pixels => 1 meter by pixel in user draw mode"
+		         setDrawModeUser.
+	layer addDShape: image.
+	
+	element geoCenter: AbsoluteCoordinates frBrest.
+	element scale: 200.
+
+	^ self openViewInWindow: element
 ]
 
 { #category : #'private - datas' }

--- a/src/GeoView-Tests/DCircleGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DCircleGeoViewProcessDataTest.class.st
@@ -15,6 +15,9 @@ DCircleGeoViewProcessDataTest >> createDShapes [
 	"Complete shape"
 	(SmockDCircle new radius: 10; coordinates: 0@0; fillColor: Color red).
 	
+	"Draw mode device (default is user)"
+	(SmockDCircle new radius: 10; coordinates: 0@0; fillColor: Color red; setDrawModeDevice).
+	
 	"With effect"
 	(SmockDCircle new radius: 10; coordinates: 0@0; fillColor: Color red; effect: (SmockDuplicateEffect new)).
 	 }

--- a/src/GeoView-Tests/DCompositeShapeGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DCompositeShapeGeoViewProcessDataTest.class.st
@@ -49,7 +49,13 @@ DCompositeShapeGeoViewProcessDataTest >> createDShapes [
 		  (SmockDCompositeShape new addChildren: {
 				   (SmockDText new key: #text1).
 				   (SmockDText new key: #text2).
-				   (SmockDText new key: #text3) }) 
+				   (SmockDText new key: #text3) }).
+				
+		"Draw mode device (default is user)" 
+		(SmockDCompositeShape new addChildren: {
+				   (SmockDText new key: #text1).
+				   (SmockDText new key: #text2).
+				   (SmockDText new key: #text3) }) setDrawModeDevice.
 		}
 ]
 

--- a/src/GeoView-Tests/DEllipseGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DEllipseGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DEllipseGeoViewProcessDataTest >> createDShapes [
 	SmockDEllipse new .
 	
 	"Complete shape"
-	(SmockDEllipse new radius1: 10; radius2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red)
+	(SmockDEllipse new radius1: 10; radius2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDEllipse new radius1: 10; radius2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red; setDrawModeDevice).
 	 }
 ]
 

--- a/src/GeoView-Tests/DImageGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DImageGeoViewProcessDataTest.class.st
@@ -8,12 +8,18 @@ Class {
 DImageGeoViewProcessDataTest >> createDShapes [
 	"Create a list of DShape to execute several tests"
 
+	| form |
+	form := (self iconNamed: #pharo).
+
 	^ { 
 	"Empty shape"
 	SmockDImage new .
 	
 	"Complete shape"
-	(SmockDImage new image: Form new; orientation: 45; scale: 2@2; coordinates: 0@0; fillColor: Color red)
+	(SmockDImage new image: form; orientation: 45; scale: 2@2; coordinates: 0@0; fillColor: Color red).
+	
+	"Draw mode user (default is device)"
+	(SmockDImage new image: form; orientation: 45; coordinates: 0@0; fillColor: Color red; setDrawModeUser)
 	 }
 ]
 

--- a/src/GeoView-Tests/DMultiPolylinesGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DMultiPolylinesGeoViewProcessDataTest.class.st
@@ -16,7 +16,10 @@ DMultiPolylinesGeoViewProcessDataTest >> createDShapes [
 	(SmockDMultiPolylines new addPolylines: { SmockDPolyline new . SmockDPolyline new . SmockDPolyline new }; fillColor: Color red) .
 	
 	"With polylines"
-	(SmockDMultiPolylines new addPolylines: { SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint } . SmockDPolyline new points: { 3 asPoint . 4 asPoint . 5 asPoint } . SmockDPolyline new points: { 6 asPoint . 7 asPoint . 8 asPoint } }; fillColor: Color red)
+	(SmockDMultiPolylines new addPolylines: { SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint } . SmockDPolyline new points: { 3 asPoint . 4 asPoint . 5 asPoint } . SmockDPolyline new points: { 6 asPoint . 7 asPoint . 8 asPoint } }; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDMultiPolylines new addPolylines: { SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint } . SmockDPolyline new points: { 3 asPoint . 4 asPoint . 5 asPoint } . SmockDPolyline new points: { 6 asPoint . 7 asPoint . 8 asPoint } }; fillColor: Color red; setDrawModeDevice).
 	 }
 ]
 

--- a/src/GeoView-Tests/DPolygonGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DPolygonGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DPolygonGeoViewProcessDataTest >> createDShapes [
 	SmockDPolygon new .
 	
 	"Complete shape"
-	(SmockDPolygon new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red)
+	(SmockDPolygon new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDPolygon new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red) setDrawModeDevice.
 	 }
 ]
 

--- a/src/GeoView-Tests/DPolylineGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DPolylineGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DPolylineGeoViewProcessDataTest >> createDShapes [
 	SmockDPolyline new .
 	
 	"Complete shape"
-	(SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red)
+	(SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDPolyline new points: { 0 asPoint . 1 asPoint . 2 asPoint }; fillColor: Color red) setDrawModeDevice.
 	 }
 ]
 

--- a/src/GeoView-Tests/DRectangleGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DRectangleGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DRectangleGeoViewProcessDataTest >> createDShapes [
 	SmockDRectangle new .
 	
 	"Complete shape"
-	(SmockDRectangle new length1: 10; length2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red)
+	(SmockDRectangle new length1: 10; length2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDRectangle new length1: 10; length2: 20; orientation: 45; coordinates: 0@0; fillColor: Color red; setDrawModeDevice).
 	 }
 ]
 

--- a/src/GeoView-Tests/DSectorGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DSectorGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DSectorGeoViewProcessDataTest >> createDShapes [
 	SmockDSector new .
 	
 	"Complete shape"
-	(SmockDSector new aperture: 10; radius: 20; orientation: 45; coordinates: 0@0; fillColor: Color red)
+	(SmockDSector new aperture: 10; radius: 20; orientation: 45; coordinates: 0@0; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDSector new aperture: 10; radius: 20; orientation: 45; coordinates: 0@0; fillColor: Color red; setDrawModeDevice).
 	 }
 ]
 

--- a/src/GeoView-Tests/DSegmentGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DSegmentGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DSegmentGeoViewProcessDataTest >> createDShapes [
 	SmockDSegment new .
 	
 	"Complete shape"
-	(SmockDSegment new coordinates: 0@0; coordinates2: 2@2; fillColor: Color red)
+	(SmockDSegment new coordinates: 0@0; coordinates2: 2@2; fillColor: Color red).
+	
+	"Draw mode device (default is user)"
+	(SmockDSegment new coordinates: 0@0; coordinates2: 2@2; fillColor: Color red; setDrawModeDevice).
 	 }
 ]
 

--- a/src/GeoView-Tests/DSymbolGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DSymbolGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DSymbolGeoViewProcessDataTest >> createDShapes [
 	SmockDSymbol new .
 	
 	"Complete shape"
-	(SmockDSymbol new coordinates: 0@0; orientation: 45; symbolKey: #mySymbol)
+	(SmockDSymbol new coordinates: 0@0; orientation: 45; symbolKey: #mySymbol).
+	
+	"Draw mode user (default is device)"
+	(SmockDSymbol new coordinates: 0@0; orientation: 45; symbolKey: #mySymbol; setDrawModeUser).
 	 }
 ]
 

--- a/src/GeoView-Tests/DTextGeoViewProcessDataTest.class.st
+++ b/src/GeoView-Tests/DTextGeoViewProcessDataTest.class.st
@@ -13,7 +13,10 @@ DTextGeoViewProcessDataTest >> createDShapes [
 	SmockDText new .
 	
 	"Complete shape"
-	(SmockDText new coordinates: 0@0; text: 'Test'; smockFont: (SmockFont defaultFont fontSize: 20))
+	(SmockDText new coordinates: 0@0; text: 'Test'; smockFont: (SmockFont defaultFont fontSize: 20)).
+	
+	"Draw mode user (default is device)"
+	(SmockDText new coordinates: 0@0; text: 'Test'; smockFont: (SmockFont defaultFont fontSize: 20); setDrawModeUser).
 	 }
 ]
 

--- a/src/GeoView/DImageGeoViewProcessData.class.st
+++ b/src/GeoView/DImageGeoViewProcessData.class.st
@@ -21,12 +21,27 @@ DImageGeoViewProcessData >> processUpdatedData: aKey incoming: aDImage with: aGB
 
 	"transformations from expected trigonometric degrees to trigonometric degrees"
 	aGBitmap2D rotation: (aDImage orientation % 360).	
-	aGBitmap2D scale: aDImage scale.
 
-	aDImage isDrawModeUser ifTrue:[ 
-		aGBitmap2D form ifNotNil:[
-			aGBitmap2D scale: (aGBitmap2D form extent x * self processor projection metersByPixel ) asPoint.
-		].
+	aDImage isDrawModeUser ifTrue:[ | extent projectedExtent newScale metersByPixel |
+		"Draw mode user, compute the scale to corresponding to the projection and use the DImage scale to adapt the final real scale. By default, with a 1@1 scale, one pixel = one meter"
+		aGBitmap2D form ifNil:[ ^ aGBitmap2D ].
+
+		extent := aGBitmap2D form extent.
+		(extent x = 0 or:[extent y = 0]) ifTrue:[ ^ aGBitmap2D ].
+		
+		metersByPixel := self processor projection metersByPixel.
+		metersByPixel = 0 ifTrue:[ ^ aGBitmap2D ].
+		projectedExtent := extent * metersByPixel.
+		
+		"Compute the scale, use DImage scale to setup the real scale"
+		newScale := (projectedExtent / extent) * (aDImage scale).
+		
+		"use scale x to build final scale, because a bitmap is a matrix of squared pixels"
+		aGBitmap2D scale: (newScale x asPoint). 
+		
+	] ifFalse:[
+		"Draw mode device, set the image scale directly"
+		aGBitmap2D scale: aDImage scale.
 	].
 
 	^ aGBitmap2D 


### PR DESCRIPTION
…st + write an example.

Enrich process data tests with device/user mode alternative for each shapes, even if this is not yet supported, this can help to detect bugs.

Fix issue #154 
Works better with https://github.com/OpenSmock/OpenSmock/pull/104 